### PR TITLE
Fix bug on DM handle

### DIFF
--- a/internal/bot/bot.go
+++ b/internal/bot/bot.go
@@ -93,7 +93,7 @@ func (b *Bot) Run() {
 }
 
 func (b *Bot) onMessageCreate(_ *dg.Session, m *dg.MessageCreate) {
-	glog.V(debug).Infof("Channel \"%s\": Get message", *ds.ChannelUnsafe(m.ChannelID))
+	glog.V(debug).Infof("Channel \"%s\": Get message", ds.ChannelUnsafe(m.ChannelID))
 
 	if m.Author.ID == ds.State.User.ID {
 		glog.V(debug).Infoln("Ignore self message")
@@ -120,11 +120,11 @@ func (b *Bot) onMessageCreate(_ *dg.Session, m *dg.MessageCreate) {
 
 	st, err := b.mts.GetMatchStatus(m.ChannelID)
 	if errors.Is(err, errs.MatchNotFound) {
-		glog.V(info).Infof("Channel \"%s\": can't get match status", *ds.ChannelUnsafe(m.ChannelID), err)
+		glog.V(info).Infof("Channel \"%s\": can't get match status: %v", ds.ChannelUnsafe(m.ChannelID), err)
 		return
 	}
 	if err != nil {
-		glog.Errorf("Channel \"%s\": can't get match status", *ds.ChannelUnsafe(m.ChannelID), err)
+		glog.Errorf("Channel \"%s\": can't get match status: %v", ds.ChannelUnsafe(m.ChannelID), err)
 		// Don't send message to user because avoid be troll
 		return
 	}
@@ -148,11 +148,11 @@ func (b *Bot) onMessageCreate(_ *dg.Session, m *dg.MessageCreate) {
 			return
 		}
 	}
-	glog.Warningf("Channel \"%s\": Message \"%s\" is not handled", *ds.ChannelUnsafe(m.ChannelID), m.ContentWithMentionsReplaced())
+	glog.Warningf("Channel \"%s\": Message \"%s\" is not handled", ds.ChannelUnsafe(m.ChannelID), m.ContentWithMentionsReplaced())
 }
 
 func (b *Bot) onMessageReaction(_ *dg.Session, m *dg.MessageReactionAdd) {
-	glog.V(debug).Infof("Channel \"%s\": Get reaction", *ds.ChannelUnsafe(m.ChannelID))
+	glog.V(debug).Infof("Channel \"%s\": Get reaction", ds.ChannelUnsafe(m.ChannelID))
 
 	if m.UserID == ds.State.User.ID {
 		glog.V(debug).Infoln("Ignore self reaction")
@@ -161,17 +161,17 @@ func (b *Bot) onMessageReaction(_ *dg.Session, m *dg.MessageReactionAdd) {
 
 	mt, err := b.mts.GetMatchByTChID(m.ChannelID)
 	if err != nil {
-		glog.V(debug).Infof("Channel \"%s\": Ignore reaction because %s", *ds.ChannelUnsafe(m.ChannelID), err)
+		glog.V(debug).Infof("Channel \"%s\": Ignore reaction because %s", ds.ChannelUnsafe(m.ChannelID), err)
 		return
 	}
 
 	st, err := b.mts.GetMatchStatus(m.ChannelID)
 	if errors.Is(err, errs.MatchNotFound) {
-		glog.V(info).Infof("Channel \"%s\": can't get match status", *ds.ChannelUnsafe(m.ChannelID), err)
+		glog.V(info).Infof("Channel \"%s\": can't get match status", ds.ChannelUnsafe(m.ChannelID), err)
 		return
 	}
 	if err != nil {
-		glog.Errorf("Channel \"%s\": can't get match status", *ds.ChannelUnsafe(m.ChannelID), err)
+		glog.Errorf("Channel \"%s\": can't get match status", ds.ChannelUnsafe(m.ChannelID), err)
 		// Don't send message to user because avoid be troll
 		return
 	}
@@ -181,15 +181,15 @@ func (b *Bot) onMessageReaction(_ *dg.Session, m *dg.MessageReactionAdd) {
 
 	// TODO: Make listening message have callback that handle reaction
 	if !b.mts.IsListeningMessage(m.ChannelID, m.MessageID) {
-		glog.V(debug).Infof("Channel \"%s\": Ignore reaction because message is not listened", *ds.ChannelUnsafe(m.ChannelID))
+		glog.V(debug).Infof("Channel \"%s\": Ignore reaction because message is not listened", ds.ChannelUnsafe(m.ChannelID))
 		return
 	}
 
 	if m.Emoji.Name == Stamp["y"] {
-		glog.V(debug).Infof("Channel \"%s\": Select yes", *ds.ChannelUnsafe(m.ChannelID))
+		glog.V(debug).Infof("Channel \"%s\": Select yes", ds.ChannelUnsafe(m.ChannelID))
 		vch, err := mt.GetRecommendedChannel()
 		if err != nil {
-			glog.Errorf("Channel \"%s\": can't get recommended channel", *ds.ChannelUnsafe(m.ChannelID))
+			glog.Errorf("Channel \"%s\": can't get recommended channel", ds.ChannelUnsafe(m.ChannelID))
 			ds.ChannelMessageSend(
 				m.ChannelID,
 				msgs.UnknownError.Format(),
@@ -206,13 +206,13 @@ func (b *Bot) onMessageReaction(_ *dg.Session, m *dg.MessageReactionAdd) {
 			ds.ChannelMessageSend(m.ChannelID, msgs.AskTeam1VCh.Format())
 			return
 		} else if err != nil {
-			glog.Errorf("Channel \"%s\": Cannot set voice channel because %s", *ds.ChannelUnsafe(m.ChannelID), err)
+			glog.Errorf("Channel \"%s\": Cannot set voice channel because %s", ds.ChannelUnsafe(m.ChannelID), err)
 			return
 		}
 
 		glog.V(info).Infof(
 			"Channel \"%s\": Team1 use \"%s\" channel",
-			*ds.ChannelUnsafe(m.ChannelID),
+			ds.ChannelUnsafe(m.ChannelID),
 			vch.Name,
 		)
 		ds.ChannelMessageSend(
@@ -226,14 +226,14 @@ func (b *Bot) onMessageReaction(_ *dg.Session, m *dg.MessageReactionAdd) {
 		return
 	}
 	if m.Emoji.Name == Stamp["n"] {
-		glog.V(debug).Infof("Channel \"%s\": Select no", *ds.ChannelUnsafe(m.ChannelID))
+		glog.V(debug).Infof("Channel \"%s\": Select no", ds.ChannelUnsafe(m.ChannelID))
 		ds.ChannelMessageSend(
 			m.ChannelID,
 			msgs.RequestChName.Format(),
 		)
 		return
 	}
-	glog.Warningf("Channel \"%s\": Reaction \"%s\" is not handled", *ds.ChannelUnsafe(m.ChannelID), m.Emoji.Name)
+	glog.Warningf("Channel \"%s\": Reaction \"%s\" is not handled", ds.ChannelUnsafe(m.ChannelID), m.Emoji.Name)
 }
 func (b *Bot) onEnable(g *dg.Guild) {
 	chs, err := ds.GuildChannels(g.ID)
@@ -256,14 +256,14 @@ func (b *Bot) onEnable(g *dg.Guild) {
 		msgs.Help.Format(),
 	)
 	if err != nil {
-		glog.Errorf("Channel \"%s\": Cannot send hello message because %s", *ds.ChannelUnsafe(tchs[0].ID), err)
+		glog.Errorf("Channel \"%s\": Cannot send hello message because %s", ds.ChannelUnsafe(tchs[0].ID), err)
 		return
 	}
 	glog.V(info).Infof("Guild \"%s\": Send hello to \"%s\" channel", g.Name, tchs[0].Name)
 }
 
 func (b *Bot) cmdStart(m *dg.MessageCreate) {
-	tch, err := ds.State.Channel(m.ChannelID)
+	tch, err := ds.Channel(m.ChannelID)
 	if err != nil {
 		glog.Errorf("can't get channel: %v", err)
 		ds.ChannelMessageSend(
@@ -274,14 +274,14 @@ func (b *Bot) cmdStart(m *dg.MessageCreate) {
 	}
 	_, err = b.mts.CreateMatch(tch)
 	if errors.Is(err, errs.MatchAlreadyStarted) {
-		glog.Warningf("Channel \"%s\": Match already started", *ds.ChannelUnsafe(m.ChannelID))
+		glog.Warningf("Channel \"%s\": Match already started", ds.ChannelUnsafe(m.ChannelID))
 		ds.ChannelMessageSend(
 			m.ChannelID,
 			msgs.MatchAlreadyStarted.Format(),
 		)
 		return
 	} else if err != nil {
-		glog.Errorf("Channel \"%s\": Cannot handle start command because %s", *ds.ChannelUnsafe(m.ChannelID), err)
+		glog.Errorf("Channel \"%s\": Cannot handle start command because %s", ds.ChannelUnsafe(m.ChannelID), err)
 		ds.ChannelMessageSend(
 			m.ChannelID,
 			msgs.UnknownError.Format(),
@@ -291,30 +291,30 @@ func (b *Bot) cmdStart(m *dg.MessageCreate) {
 
 	err = b.recommendChannel(m.ChannelID)
 	if errors.Is(err, errs.NoAvailableVCh) {
-		glog.Warningf("Channel \"%s\": Cannot recommend voice channel because %s", *ds.ChannelUnsafe(m.ChannelID), err)
+		glog.Warningf("Channel \"%s\": Cannot recommend voice channel because %s", ds.ChannelUnsafe(m.ChannelID), err)
 		ds.ChannelMessageSend(
 			m.ChannelID,
 			msgs.NoVChAvailable.Format(),
 		)
 		return
 	} else if err != nil {
-		glog.Errorf("Channel \"%s\": Cannot recommend voice channel because %s", *ds.ChannelUnsafe(m.ChannelID), err)
+		glog.Errorf("Channel \"%s\": Cannot recommend voice channel because %s", ds.ChannelUnsafe(m.ChannelID), err)
 		ds.ChannelMessageSend(
 			m.ChannelID,
 			msgs.UnknownError.Format(),
 		)
 		return
 	}
-	glog.V(debug).Infof("Channel \"%s\": Match started", *ds.ChannelUnsafe(m.ChannelID))
+	glog.V(debug).Infof("Channel \"%s\": Match started", ds.ChannelUnsafe(m.ChannelID))
 }
 
 func (b *Bot) cmdExit(m *dg.MessageCreate) {
 	err := b.mts.RemoveMatch(m.ChannelID)
 	if errors.Is(err, errs.MatchNotFound) {
-		glog.Warningf("Channel \"%s\": Match not found", *ds.ChannelUnsafe(m.ChannelID))
+		glog.Warningf("Channel \"%s\": Match not found", ds.ChannelUnsafe(m.ChannelID))
 		return
 	} else if err != nil {
-		glog.Errorf("Channel \"%s\": Cannot handle end command because %s", *ds.ChannelUnsafe(m.ChannelID), err)
+		glog.Errorf("Channel \"%s\": Cannot handle end command because %s", ds.ChannelUnsafe(m.ChannelID), err)
 		ds.ChannelMessageSend(
 			m.ChannelID,
 			msgs.UnknownError.Format(),
@@ -325,7 +325,7 @@ func (b *Bot) cmdExit(m *dg.MessageCreate) {
 		m.ChannelID,
 		msgs.Exit.Format(),
 	)
-	glog.V(info).Infof("Channel \"%s\": match has deleted", *ds.ChannelUnsafe(m.ChannelID))
+	glog.V(info).Infof("Channel \"%s\": match has deleted", ds.ChannelUnsafe(m.ChannelID))
 }
 
 func (b *Bot) cmdHelp(m *dg.MessageCreate) {
@@ -334,20 +334,20 @@ func (b *Bot) cmdHelp(m *dg.MessageCreate) {
 		msgs.Help.Format(),
 	)
 	if err != nil {
-		glog.Errorf("Channel \"%s\": Cannot handle help command because %s", *ds.ChannelUnsafe(m.ChannelID), err)
+		glog.Errorf("Channel \"%s\": Cannot handle help command because %s", ds.ChannelUnsafe(m.ChannelID), err)
 		ds.ChannelMessageSend(
 			m.ChannelID,
 			msgs.UnknownError.Format(),
 		)
 		return
 	}
-	glog.V(info).Infof("Channel \"%s\": Help message sent", *ds.ChannelUnsafe(m.ChannelID))
+	glog.V(info).Infof("Channel \"%s\": Help message sent", ds.ChannelUnsafe(m.ChannelID))
 }
 
 func (b *Bot) cmdShuffle(m *dg.MessageCreate) {
 	g, err := ds.State.Guild(m.GuildID)
 	if err != nil {
-		glog.Errorf("Channel \"%s\": Cannot get guild", *ds.ChannelUnsafe(m.ChannelID))
+		glog.Errorf("Channel \"%s\": Cannot get guild", ds.ChannelUnsafe(m.ChannelID))
 		return
 	}
 	err = b.mts.ShuffleTeam(m.ChannelID, g.VoiceStates)
@@ -424,7 +424,7 @@ func (b *Bot) handleVChSettingMessage(tchID, content string, st match.Status) {
 					glog.Errorf("can't get guild: $v", err)
 					return
 				}
-				if len(g.VoiceStates) != 0 {
+				if len(g.VoiceStates) > 0 {
 					err = b.mts.ShuffleTeam(tchID, g.VoiceStates)
 					if err != nil {
 						glog.Errorf("can't shuffle team: %v", err)
@@ -445,7 +445,7 @@ func (b *Bot) handleVChSettingMessage(tchID, content string, st match.Status) {
 			return
 		}
 	}
-	glog.V(info).Infof("Channel: \"%s\": Message ignore", *ds.ChannelUnsafe(tchID))
+	glog.V(info).Infof("Channel: \"%s\": Message ignore", ds.ChannelUnsafe(tchID))
 	ds.ChannelMessageSend(tchID, "？")
 }
 
@@ -529,7 +529,7 @@ func (b *Bot) movePlayers(tchID string) error {
 	for _, p := range team1 {
 		err := ds.GuildMemberMove(mt.GetGuildId(), p, &mt.Team1VCh.ID)
 		if err != nil {
-			glog.Errorf("Channel \"%s\": Cannot move member because %s", *ds.ChannelUnsafe(tchID), err)
+			glog.Errorf("Channel \"%s\": Cannot move member because %s", ds.ChannelUnsafe(tchID), err)
 			ds.ChannelMessageSend(tchID, msgs.UnknownError.Format())
 			return err
 		}
@@ -537,7 +537,7 @@ func (b *Bot) movePlayers(tchID string) error {
 	for _, p := range team2 {
 		err := ds.GuildMemberMove(mt.GetGuildId(), p, &mt.Team2VCh.ID)
 		if err != nil {
-			glog.Errorf("Channel \"%s\": Cannot move member because %s", *ds.ChannelUnsafe(tchID), err)
+			glog.Errorf("Channel \"%s\": Cannot move member because %s", ds.ChannelUnsafe(tchID), err)
 			ds.ChannelMessageSend(tchID, msgs.UnknownError.Format())
 			return err
 		}

--- a/pkg/discord/discord.go
+++ b/pkg/discord/discord.go
@@ -23,13 +23,12 @@ func New(s *dg.Session) *Session {
 	return &Session{s, &Utility{}}
 }
 
-// No error handling
-func (s *Session) ChannelUnsafe(chID string) *string {
-	ch, err := s.State.Channel(chID)
+func (s *Session) ChannelUnsafe(chID string) string {
+	ch, err := s.Channel(chID)
 	if err != nil {
-		return nil
+		return ""
 	}
-	return &ch.Name
+	return ch.Name
 }
 
 func (u *Utility) Channels2IDs(chs []*dg.Channel) []string {


### PR DESCRIPTION
Resolve #6 
The bot crashed while processing the DM.
There are two reasons:
1. `discordgo.Session.State.Channel` does not have a DM channel.
2. The wrapper method `discord.Session.ChannelUnsafe` returned nil and was referenced by the logging message.